### PR TITLE
Transform the psuedo code into rust code

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -11,13 +11,13 @@ struct Cpu {
 }
 
 enum Flags {
-    CA = 0b00000001,   // Carry
-    ZE = 0b00000010,   // Zero
-    ID = 0b00000100,   // Interrupt Disable
-    DC = 0b00001000,   // Decimal 
-    B1 = 0b00010000,  // B flag bit one
-    B2 = 0b00100000,  // B flag bit two
-    OV = 0b01000000,  // Overflow
+    CA = 0b00000001, // Carry
+    ZE = 0b00000010, // Zero
+    ID = 0b00000100, // Interrupt Disable
+    DC = 0b00001000, // Decimal 
+    B1 = 0b00010000, // B flag bit one
+    B2 = 0b00100000, // B flag bit two
+    OV = 0b01000000, // Overflow
     NG = 0b10000000, // Negative
 }
 
@@ -104,20 +104,27 @@ impl Cpu {
     // Setup functions
     pub fn new(bus: &Bus) -> Self {
         Self { 
-            0, 0, 0, 0x8000, 0, 0, 0, bus
+            a: 0u8,
+            x: 0u8,
+            y: 0u8,
+            pc: 0x8000,
+            stp: 0u8,
+            stat: 0u8,
+            cycl: 0u8,
+            bus: bus
         }
     }
 
     // Interface functions
     pub fn clock(&self) {
-        if self.cycle == 0 {
+        if self.cycl == 0 {
             let opcode:u8 = self.read(self.pc);
             self.pc += 1;
             
             let operand = self.set_address_mode(opcode);
             self.cycl += self.execute(opcode, operand);
         }
-        self.cycle -= 1;
+        self.cycl -= 1;
     }
 
     pub fn reset() {}
@@ -133,14 +140,15 @@ impl Cpu {
         }
     }
 
+    // Reads an address in memory
     fn read(&self, addr: u16) -> u8 {
         return self.bus.read(addr);
     }
+    // Writes a value to memory
     fn write(&self, addr: u16, value: u8) {
         self.bus.write(addr, value);
     }
 
-    
     fn set_address_mode(&self, opcode: u8) {
         match ADDRESSING_MODE_LOOKUP[opcode] {
             IMD => {
@@ -150,6 +158,7 @@ impl Cpu {
         }
     }
 
+    // Given an opcode, finds the amount of consecutive bits in memory to read, 
     fn execute(&self, opcode: u8, operand: u8) -> u8 {
         let opcode = self.read(self.pc);
         self.pc += 1;
@@ -163,7 +172,7 @@ impl Cpu {
             }
         }
 
-        return  opcodeCycles;
+        return opcode_cycles;
     }
 
 }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -21,7 +21,7 @@ enum Flags {
     NG = 0b10000000, // Negative
 }
 
-enum AddressingModes {
+enum AddrM {
     IMP, // Implicit
     ACC, // Accumulator
     IMD, // Immediate
@@ -60,22 +60,22 @@ let addressingModesFull6502: [u8, 0xFF] = [
 ]*/
 
 const ADDRESSING_MODE_LOOKUP: [u8; 0xFF] = [
-   AddressingModes::IMP, AddressingModes::IIX, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::ZPG, AddressingModes::ZPG, AddressingModes::NUL, AddressingModes::IMP, AddressingModes::IMD, AddressingModes::ACC, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::ABS, AddressingModes::ABS, AddressingModes::NUL,
-   AddressingModes::REL, AddressingModes::IIY, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::ZIX, AddressingModes::ZIX, AddressingModes::NUL, AddressingModes::IMP, AddressingModes::AIY, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::AIX, AddressingModes::AIX, AddressingModes::NUL,
-   AddressingModes::ABS, AddressingModes::IIX, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::ZPG, AddressingModes::ZPG, AddressingModes::ZPG, AddressingModes::NUL, AddressingModes::IMP, AddressingModes::IMD, AddressingModes::ACC, AddressingModes::NUL, AddressingModes::ABS, AddressingModes::ABS, AddressingModes::ABS, AddressingModes::NUL,
-   AddressingModes::REL, AddressingModes::IIY, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::ZIX, AddressingModes::ZIX, AddressingModes::NUL, AddressingModes::IMP, AddressingModes::AIY, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::AIX, AddressingModes::AIX, AddressingModes::NUL,
-   AddressingModes::IMP, AddressingModes::IIX, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::ZPG, AddressingModes::ZPG, AddressingModes::NUL, AddressingModes::IMP, AddressingModes::IMD, AddressingModes::ACC, AddressingModes::NUL, AddressingModes::ABS, AddressingModes::ABS, AddressingModes::ABS, AddressingModes::NUL,
-   AddressingModes::REL, AddressingModes::IIY, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::ZIX, AddressingModes::ZIX, AddressingModes::NUL, AddressingModes::IMP, AddressingModes::AIY, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::AIX, AddressingModes::AIX, AddressingModes::NUL,
-   AddressingModes::IMP, AddressingModes::IIX, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::ZPG, AddressingModes::ZPG, AddressingModes::NUL, AddressingModes::IMP, AddressingModes::IMD, AddressingModes::ACC, AddressingModes::NUL, AddressingModes::IND, AddressingModes::ABS, AddressingModes::ABS, AddressingModes::NUL,
-   AddressingModes::REL, AddressingModes::IIY, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::ZIX, AddressingModes::ZIX, AddressingModes::NUL, AddressingModes::IMP, AddressingModes::AIY, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::AIX, AddressingModes::AIX, AddressingModes::NUL,
-   AddressingModes::NUL, AddressingModes::IIX, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::ZPG, AddressingModes::ZPG, AddressingModes::ZPG, AddressingModes::NUL, AddressingModes::IMP, AddressingModes::NUL, AddressingModes::IMP, AddressingModes::NUL, AddressingModes::ABS, AddressingModes::ABS, AddressingModes::ABS, AddressingModes::NUL,
-   AddressingModes::REL, AddressingModes::IIY, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::ZIX, AddressingModes::ZIX, AddressingModes::ZIY, AddressingModes::NUL, AddressingModes::IMP, AddressingModes::AIY, AddressingModes::IMP, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::AIX, AddressingModes::NUL, AddressingModes::NUL,
-   AddressingModes::IMD, AddressingModes::IIX, AddressingModes::IMD, AddressingModes::NUL, AddressingModes::ZPG, AddressingModes::ZPG, AddressingModes::ZPG, AddressingModes::NUL, AddressingModes::IMP, AddressingModes::IMD, AddressingModes::IMP, AddressingModes::NUL, AddressingModes::ABS, AddressingModes::ABS, AddressingModes::ABS, AddressingModes::NUL,
-   AddressingModes::REL, AddressingModes::IIY, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::ZIX, AddressingModes::ZIX, AddressingModes::ZIY, AddressingModes::NUL, AddressingModes::IMP, AddressingModes::AIY, AddressingModes::IMP, AddressingModes::NUL, AddressingModes::AIX, AddressingModes::AIX, AddressingModes::AIY, AddressingModes::NUL,
-   AddressingModes::IMD, AddressingModes::IIX, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::ZPG, AddressingModes::ZPG, AddressingModes::ZPG, AddressingModes::NUL, AddressingModes::IMP, AddressingModes::IMD, AddressingModes::IMP, AddressingModes::NUL, AddressingModes::ABS, AddressingModes::ABS, AddressingModes::ABS, AddressingModes::NUL,
-   AddressingModes::REL, AddressingModes::IIY, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::ZIX, AddressingModes::ZIX, AddressingModes::NUL, AddressingModes::IMP, AddressingModes::AIY, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::AIX, AddressingModes::AIX, AddressingModes::NUL,
-   AddressingModes::IMD, AddressingModes::IIX, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::ZPG, AddressingModes::ZPG, AddressingModes::ZPG, AddressingModes::NUL, AddressingModes::IMP, AddressingModes::IMD, AddressingModes::IMP, AddressingModes::NUL, AddressingModes::ABS, AddressingModes::ABS, AddressingModes::ABS, AddressingModes::NUL,
-   AddressingModes::REL, AddressingModes::IIY, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::ZIX, AddressingModes::ZIX, AddressingModes::NUL, AddressingModes::IMP, AddressingModes::AIY, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::NUL, AddressingModes::AIX, AddressingModes::AIX, AddressingModes::NUL,
+   AddrM::IMP, AddrM::IIX, AddrM::NUL, AddrM::NUL, AddrM::NUL, AddrM::ZPG, AddrM::ZPG, AddrM::NUL, AddrM::IMP, AddrM::IMD, AddrM::ACC, AddrM::NUL, AddrM::NUL, AddrM::ABS, AddrM::ABS, AddrM::NUL,
+   AddrM::REL, AddrM::IIY, AddrM::NUL, AddrM::NUL, AddrM::NUL, AddrM::ZIX, AddrM::ZIX, AddrM::NUL, AddrM::IMP, AddrM::AIY, AddrM::NUL, AddrM::NUL, AddrM::NUL, AddrM::AIX, AddrM::AIX, AddrM::NUL,
+   AddrM::ABS, AddrM::IIX, AddrM::NUL, AddrM::NUL, AddrM::ZPG, AddrM::ZPG, AddrM::ZPG, AddrM::NUL, AddrM::IMP, AddrM::IMD, AddrM::ACC, AddrM::NUL, AddrM::ABS, AddrM::ABS, AddrM::ABS, AddrM::NUL,
+   AddrM::REL, AddrM::IIY, AddrM::NUL, AddrM::NUL, AddrM::NUL, AddrM::ZIX, AddrM::ZIX, AddrM::NUL, AddrM::IMP, AddrM::AIY, AddrM::NUL, AddrM::NUL, AddrM::NUL, AddrM::AIX, AddrM::AIX, AddrM::NUL,
+   AddrM::IMP, AddrM::IIX, AddrM::NUL, AddrM::NUL, AddrM::NUL, AddrM::ZPG, AddrM::ZPG, AddrM::NUL, AddrM::IMP, AddrM::IMD, AddrM::ACC, AddrM::NUL, AddrM::ABS, AddrM::ABS, AddrM::ABS, AddrM::NUL,
+   AddrM::REL, AddrM::IIY, AddrM::NUL, AddrM::NUL, AddrM::NUL, AddrM::ZIX, AddrM::ZIX, AddrM::NUL, AddrM::IMP, AddrM::AIY, AddrM::NUL, AddrM::NUL, AddrM::NUL, AddrM::AIX, AddrM::AIX, AddrM::NUL,
+   AddrM::IMP, AddrM::IIX, AddrM::NUL, AddrM::NUL, AddrM::NUL, AddrM::ZPG, AddrM::ZPG, AddrM::NUL, AddrM::IMP, AddrM::IMD, AddrM::ACC, AddrM::NUL, AddrM::IND, AddrM::ABS, AddrM::ABS, AddrM::NUL,
+   AddrM::REL, AddrM::IIY, AddrM::NUL, AddrM::NUL, AddrM::NUL, AddrM::ZIX, AddrM::ZIX, AddrM::NUL, AddrM::IMP, AddrM::AIY, AddrM::NUL, AddrM::NUL, AddrM::NUL, AddrM::AIX, AddrM::AIX, AddrM::NUL,
+   AddrM::NUL, AddrM::IIX, AddrM::NUL, AddrM::NUL, AddrM::ZPG, AddrM::ZPG, AddrM::ZPG, AddrM::NUL, AddrM::IMP, AddrM::NUL, AddrM::IMP, AddrM::NUL, AddrM::ABS, AddrM::ABS, AddrM::ABS, AddrM::NUL,
+   AddrM::REL, AddrM::IIY, AddrM::NUL, AddrM::NUL, AddrM::ZIX, AddrM::ZIX, AddrM::ZIY, AddrM::NUL, AddrM::IMP, AddrM::AIY, AddrM::IMP, AddrM::NUL, AddrM::NUL, AddrM::AIX, AddrM::NUL, AddrM::NUL,
+   AddrM::IMD, AddrM::IIX, AddrM::IMD, AddrM::NUL, AddrM::ZPG, AddrM::ZPG, AddrM::ZPG, AddrM::NUL, AddrM::IMP, AddrM::IMD, AddrM::IMP, AddrM::NUL, AddrM::ABS, AddrM::ABS, AddrM::ABS, AddrM::NUL,
+   AddrM::REL, AddrM::IIY, AddrM::NUL, AddrM::NUL, AddrM::ZIX, AddrM::ZIX, AddrM::ZIY, AddrM::NUL, AddrM::IMP, AddrM::AIY, AddrM::IMP, AddrM::NUL, AddrM::AIX, AddrM::AIX, AddrM::AIY, AddrM::NUL,
+   AddrM::IMD, AddrM::IIX, AddrM::NUL, AddrM::NUL, AddrM::ZPG, AddrM::ZPG, AddrM::ZPG, AddrM::NUL, AddrM::IMP, AddrM::IMD, AddrM::IMP, AddrM::NUL, AddrM::ABS, AddrM::ABS, AddrM::ABS, AddrM::NUL,
+   AddrM::REL, AddrM::IIY, AddrM::NUL, AddrM::NUL, AddrM::NUL, AddrM::ZIX, AddrM::ZIX, AddrM::NUL, AddrM::IMP, AddrM::AIY, AddrM::NUL, AddrM::NUL, AddrM::NUL, AddrM::AIX, AddrM::AIX, AddrM::NUL,
+   AddrM::IMD, AddrM::IIX, AddrM::NUL, AddrM::NUL, AddrM::ZPG, AddrM::ZPG, AddrM::ZPG, AddrM::NUL, AddrM::IMP, AddrM::IMD, AddrM::IMP, AddrM::NUL, AddrM::ABS, AddrM::ABS, AddrM::ABS, AddrM::NUL,
+   AddrM::REL, AddrM::IIY, AddrM::NUL, AddrM::NUL, AddrM::NUL, AddrM::ZIX, AddrM::ZIX, AddrM::NUL, AddrM::IMP, AddrM::AIY, AddrM::NUL, AddrM::NUL, AddrM::NUL, AddrM::AIX, AddrM::AIX, AddrM::NUL,
 ];
 
 


### PR DESCRIPTION
- Shortened name of AddressingMode to AddrM
- Changed the name of some variables and such to help the code compile
